### PR TITLE
Depend on libuuid only on Linux

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 libprotobuf:
 - '3.13'
 libuuid:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,16 +11,12 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 libprotobuf:
 - '3.13'
-libuuid:
-- 2.32.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
-  libuuid:
-    max_pin: x
   zeromq:
     max_pin: x.x
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: ca97dcf6985d5b37010468b5006f3d578676757828cad6c7007e390d9974c5d0
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
@@ -27,18 +27,19 @@ requirements:
     - cmake
     - pkg-config
   host:
+    - libignition-cmake2
     - libignition-msgs6
     - libignition-tools1
     - cppzmq
     - zeromq
-    - libuuid                            # [not win]
+    - libuuid                            # [linux]
     - libprotobuf                        # [not win]
   run:
     - libignition-msgs6
     - libignition-tools1
     - cppzmq
     - zeromq
-    - libuuid                            # [not win]
+    - libuuid                            # [linux]
     - libprotobuf                        # [not win]
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]


### PR DESCRIPTION
As on macOS the libuuid dependency can create conflicts, see https://github.com/conda-forge/libignition-cmake0-feedstock/pull/7 and https://github.com/conda-forge/libuuid-feedstock/issues/16 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
