### PR TITLE
Create branch v8 for rebuild and minor releases of libignition-transport8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About libignition-transport9
+About libignition-transport8
 ============================
 
 Home: https://github.com/ignitionrobotics/ign-transport
@@ -60,27 +60,27 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-libignition--transport9-green.svg)](https://anaconda.org/conda-forge/libignition-transport9) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libignition-transport9.svg)](https://anaconda.org/conda-forge/libignition-transport9) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libignition-transport9.svg)](https://anaconda.org/conda-forge/libignition-transport9) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libignition-transport9.svg)](https://anaconda.org/conda-forge/libignition-transport9) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libignition--transport8-green.svg)](https://anaconda.org/conda-forge/libignition-transport8) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libignition-transport8.svg)](https://anaconda.org/conda-forge/libignition-transport8) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libignition-transport8.svg)](https://anaconda.org/conda-forge/libignition-transport8) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libignition-transport8.svg)](https://anaconda.org/conda-forge/libignition-transport8) |
 
-Installing libignition-transport9
+Installing libignition-transport8
 =================================
 
-Installing `libignition-transport9` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `libignition-transport8` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `libignition-transport9` can be installed with:
+Once the `conda-forge` channel has been enabled, `libignition-transport8` can be installed with:
 
 ```
-conda install libignition-transport9
+conda install libignition-transport8
 ```
 
-It is possible to list all of the versions of `libignition-transport9` available on your platform with:
+It is possible to list all of the versions of `libignition-transport8` available on your platform with:
 
 ```
-conda search libignition-transport9 --channel conda-forge
+conda search libignition-transport8 --channel conda-forge
 ```
 
 
@@ -122,17 +122,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating libignition-transport9-feedstock
+Updating libignition-transport8-feedstock
 =========================================
 
-If you would like to improve the libignition-transport9 recipe or build a new
+If you would like to improve the libignition-transport8 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/libignition-transport9-feedstock are
+Note that all branches in the conda-forge/libignition-transport8-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: caea46e51e9ebb4ad27f12ad004ed98d7b4011b601c07e6680c702f19da5cadb
 
 build:
-  number: 3
+  number: 2
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set base_name = "libignition-transport" %}
-{% set version = "9.0.0" %}
+{% set version = "8.1.0" %}
 {% set major_version = version.split('.')[0] %}
 {% set name = base_name + major_version %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-transport/archive/ignition-transport{{ major_version }}_{{ version }}.tar.gz
-    sha256: ca97dcf6985d5b37010468b5006f3d578676757828cad6c7007e390d9974c5d0
+    sha256: caea46e51e9ebb4ad27f12ad004ed98d7b4011b601c07e6680c702f19da5cadb
 
 build:
   number: 3
@@ -28,14 +28,14 @@ requirements:
     - pkg-config
   host:
     - libignition-cmake2
-    - libignition-msgs6
+    - libignition-msgs5
     - libignition-tools1
     - cppzmq
     - zeromq
     - libuuid                            # [linux]
     - libprotobuf                        # [not win]
   run:
-    - libignition-msgs6
+    - libignition-msgs5
     - libignition-tools1
     - cppzmq
     - zeromq


### PR DESCRIPTION
In particular with this change we backport the fix https://github.com/conda-forge/libignition-transport4-feedstock/pull/17 to libignition-transport8 .
The build number was set to 2 as the latest build of libignition-transport8 8.1.0 was with build number 1 (see https://anaconda.org/conda-forge/libignition-transport8/files).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
