### PR TITLE
Run bot migrations on v8 branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,2 +1,5 @@
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}
+bot:
+  abi_migration_branches:
+    - "v8"


### PR DESCRIPTION
`gazebo` is using v8 and currently the `libprotobuf314` migration is waiting for a rebuild of that to proceed. This will instruct the bot to make the respective PR on the branch.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
