### PR TITLE
Depend on libprotobuf explicitly also on Windows

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
+libprotobuf:
+- '3.15'
 pin_run_as_build:
   zeromq:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: b1382d5a5f6e3df330adb77519799f482457cad791cb48d37f8bd9066fa93302
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -30,14 +30,13 @@ requirements:
     - cppzmq
     - zeromq
     - libuuid                            # [linux]
-    - libprotobuf                        # [not win]
+    - libprotobuf
   run:
     - libignition-msgs6
     - libignition-tools1
     - cppzmq
     - zeromq
     - libuuid                            # [linux]
-    - libprotobuf                        # [not win]
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
 


### PR DESCRIPTION
See https://github.com/conda-forge/libignition-msgs1-feedstock/pull/28 for the extended discussion.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
