### PR TITLE
 Depend on libprotobuf explicitly also on Windows (for v8 branch)

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,13 +1,17 @@
+c_compiler:
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2017
+libprotobuf:
+- '3.15'
 pin_run_as_build:
   zeromq:
     max_pin: x.x.x
 target_platform:
 - win-64
-vc:
-- '14'
 zeromq:
 - 4.3.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}              # [not win]
-    - {{ compiler('c') }}                # [not win]
-    - vs2017_win-64                      # [win64]
-    - vs2017_win-32                      # [win32]
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - make                               # [not win]
     - cmake
     - pkg-config
@@ -33,14 +31,13 @@ requirements:
     - cppzmq
     - zeromq
     - libuuid                            # [linux]
-    - libprotobuf                        # [not win]
+    - libprotobuf
   run:
     - libignition-msgs5
     - libignition-tools1
     - cppzmq
     - zeromq
     - libuuid                            # [linux]
-    - libprotobuf                        # [not win]
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
     sha256: caea46e51e9ebb4ad27f12ad004ed98d7b4011b601c07e6680c702f19da5cadb
 
 build:
-  number: 4
-  skip: true  # [win and vc<14]
+  number: 5
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
I also cleaned up a bit of Windows-specific compiler leftovers.

See conda-forge/libignition-msgs1-feedstock#28 for the extended discussion.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
