### PR TITLE
Remove v9 from abi_migration_branches as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 bot:
   abi_migration_branches:
   - v8
-  - v9
   - v10
 build_platform:
   linux_aarch64: linux_64


### PR DESCRIPTION
See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md .