### PR TITLE
Drop support for v10

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,6 @@
 bot:
   abi_migration_branches:
   - v8
-  - v10
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
It reached end of life, see https://github.com/gazebo-tooling/release-tools/issues/655 .