### PR TITLE
Fix Windows build failure by backporting Windows fix

### DIFF
--- a/.ci_support/linux_64_libprotobuf3.21.yaml
+++ b/.ci_support/linux_64_libprotobuf3.21.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20230125'
 libprotobuf:
 - '3.21'
 libuuid:

--- a/.ci_support/linux_64_libprotobuf4.23.2.yaml
+++ b/.ci_support/linux_64_libprotobuf4.23.2.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20230125'
 libprotobuf:
 - 4.23.2
 libuuid:

--- a/.ci_support/linux_aarch64_libprotobuf3.21.yaml
+++ b/.ci_support/linux_aarch64_libprotobuf3.21.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20230125'
 libprotobuf:
 - '3.21'
 libuuid:

--- a/.ci_support/linux_aarch64_libprotobuf4.23.2.yaml
+++ b/.ci_support/linux_aarch64_libprotobuf4.23.2.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20230125'
 libprotobuf:
 - 4.23.2
 libuuid:

--- a/.ci_support/linux_ppc64le_libprotobuf3.21.yaml
+++ b/.ci_support/linux_ppc64le_libprotobuf3.21.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20230125'
 libprotobuf:
 - '3.21'
 libuuid:

--- a/.ci_support/linux_ppc64le_libprotobuf4.23.2.yaml
+++ b/.ci_support/linux_ppc64le_libprotobuf4.23.2.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20230125'
 libprotobuf:
 - 4.23.2
 libuuid:

--- a/.ci_support/osx_64_libprotobuf3.21.yaml
+++ b/.ci_support/osx_64_libprotobuf3.21.yaml
@@ -12,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libabseil:
+- '20230125'
 libprotobuf:
 - '3.21'
 macos_machine:

--- a/.ci_support/osx_64_libprotobuf4.23.2.yaml
+++ b/.ci_support/osx_64_libprotobuf4.23.2.yaml
@@ -12,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libabseil:
+- '20230125'
 libprotobuf:
 - 4.23.2
 macos_machine:

--- a/.ci_support/osx_arm64_libprotobuf3.21.yaml
+++ b/.ci_support/osx_arm64_libprotobuf3.21.yaml
@@ -12,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libabseil:
+- '20230125'
 libprotobuf:
 - '3.21'
 macos_machine:

--- a/.ci_support/osx_arm64_libprotobuf4.23.2.yaml
+++ b/.ci_support/osx_arm64_libprotobuf4.23.2.yaml
@@ -12,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libabseil:
+- '20230125'
 libprotobuf:
 - 4.23.2
 macos_machine:

--- a/.ci_support/win_64_libprotobuf3.21.yaml
+++ b/.ci_support/win_64_libprotobuf3.21.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20230125'
 libprotobuf:
 - '3.21'
 target_platform:

--- a/.ci_support/win_64_libprotobuf4.23.2.yaml
+++ b/.ci_support/win_64_libprotobuf4.23.2.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20230125'
 libprotobuf:
 - 4.23.2
 target_platform:

--- a/recipe/406.patch
+++ b/recipe/406.patch
@@ -1,0 +1,29 @@
+diff --git a/include/gz/transport/TopicStatistics.hh b/include/gz/transport/TopicStatistics.hh
+index 3bdf5a755..c547d5c0d 100644
+--- a/include/gz/transport/TopicStatistics.hh
++++ b/include/gz/transport/TopicStatistics.hh
+@@ -19,12 +19,24 @@
+ 
+ #include <gz/msgs/statistic.pb.h>
+ 
++#include <algorithm>
+ #include <limits>
+ #include <memory>
+ #include <string>
+ #include "gz/transport/config.hh"
+ #include "gz/transport/Export.hh"
+ 
++#ifdef _WIN32
++#ifndef NOMINMAX
++  #define NOMINMAX
++#endif
++#ifdef min
++  #undef min
++  #undef max
++#endif
++#include <windows.h>
++#endif
++
+ namespace ignition
+ {
+   namespace transport

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
     sha256: 65472a874bbb0f6bb686b3c0cce4146fb650e750f8f795a159523ecbe731c1c7
     patches:
       - 405.patch
+      - 406.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1425 by backporting https://github.com/gazebosim/gz-transport/pull/250/files .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
